### PR TITLE
added return true to didTransition and willTransition events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
+/.idea

--- a/addon/mixins/linkable.js
+++ b/addon/mixins/linkable.js
@@ -101,6 +101,7 @@ export default Ember.Mixin.create({
     willTransition() {
       this._super.apply(this, arguments);
       this.removeLinksFromHead();
+      return true;
     },
 
     /*
@@ -113,6 +114,7 @@ export default Ember.Mixin.create({
     didTransition() {
       this._super.apply(this, arguments);
       Ember.run.next(this, this.addLinksToHead);
+      return true;
     }
   }
 });


### PR DESCRIPTION
 in the mixin so they propagate up the chain.

Tried implementing this in our ember project and we had some didTransition event handlers in our application route that weren't being called because this mixin was intercepting them and not propagating them properly. By setting return true, the event propagates up the chain.
